### PR TITLE
Add support for relaying bot messages

### DIFF
--- a/mautrix_instagram/portal.py
+++ b/mautrix_instagram/portal.py
@@ -293,7 +293,7 @@ class Portal(DBPortal, BasePortal):
         self._reqid_dedup.add(request_id)
         self.log.debug(f"Handling Matrix message {event_id} from {sender.mxid}/{sender.igpk} "
                        f"with request ID {request_id}")
-        if message.msgtype in (MessageType.EMOTE, MessageType.TEXT):
+        if message.msgtype in (MessageType.EMOTE, MessageType.TEXT, MessageType.NOTICE):
             text = message.body
             if message.msgtype == MessageType.EMOTE:
                 text = f"/me {text}"


### PR DESCRIPTION
Messages of MessageType.NOTICE previously led to a crash.
This PR fixes #32
