### PR TITLE
Make mutation_token optional for LinkItem

### DIFF
--- a/mauigpapi/types/thread_item.py
+++ b/mauigpapi/types/thread_item.py
@@ -408,7 +408,7 @@ class LinkItem(SerializableAttrs):
     text: str
     link_context: LinkContext
     client_context: str
-    mutation_token: str
+    mutation_token: Optional[str]
 
 
 class ReelShareType(SerializableEnum):


### PR DESCRIPTION
Fails to deserialize LinkItem when mutation_token is missing, make it optional
![LinkItem](https://user-images.githubusercontent.com/19787065/148986553-9fdef7b1-d20c-4b4b-a8c8-19b2ed8fc664.png)