### PR TITLE
Update Video and Image Version models

### DIFF
--- a/mauigpapi/types/thread_item.py
+++ b/mauigpapi/types/thread_item.py
@@ -105,11 +105,19 @@ class CreateModeAttribution(SerializableAttrs):
 
 
 @dataclass(kw_only=True)
+class FallbackMedia(SerializableAttrs):
+    url: str
+
+
+@dataclass(kw_only=True)
 class ImageVersion(SerializableAttrs):
     width: int
     height: int
     url: str
     estimated_scan_sizes: Optional[List[int]] = None
+    fallback: Optional[FallbackMedia] = None
+    url_expiration_timestamp_us: Optional[int] = None
+    scans_profile: Optional[str] = None
 
 
 @dataclass(kw_only=True)
@@ -123,7 +131,9 @@ class VideoVersion(SerializableAttrs):
     width: int
     height: int
     url: str
-    id: str
+    id: Optional[str] = None
+    url_expiration_timestamp_us: Optional[int] = None
+    fallback: Optional[FallbackMedia] = None
 
 
 class MediaType(SerializableEnum):


### PR DESCRIPTION
Create fallbackmedia class - url
add fallback, expiration_timestamp_us, scans_profile to ImageVersion
add fallback, expiration_timestamp_us to VideoVersion
make id optional for VideoVersion
![MediaVersions](https://user-images.githubusercontent.com/19787065/149001507-3d05bcbf-83c5-4750-9058-ab30da711237.png)

