### PR TITLE
Add SQLite support

### DIFF
--- a/mautrix_instagram/db/__init__.py
+++ b/mautrix_instagram/db/__init__.py
@@ -7,6 +7,24 @@ from .reaction import Reaction
 from .upgrade import upgrade_table
 from .user import User
 
+try:
+    import asyncpg
+
+    UniqueError = asyncpg.UniqueViolationError
+    Record = asyncpg.Record
+except ImportError:
+    pass
+try:
+    import sqlite3
+
+    UniqueError = sqlite3.IntegrityError
+    Record = sqlite3.Row
+except ImportError:
+    pass
+
+if UniqueError is None:
+    raise ImportError("Must require either asyncpg or aiosqlite!")
+
 
 def init(db: Database) -> None:
     for table in (User, Puppet, Portal, Message, Reaction):

--- a/mautrix_instagram/db/__init__.py
+++ b/mautrix_instagram/db/__init__.py
@@ -6,24 +6,7 @@ from .puppet import Puppet
 from .reaction import Reaction
 from .upgrade import upgrade_table
 from .user import User
-
-try:
-    import asyncpg
-
-    UniqueError = asyncpg.UniqueViolationError
-    Record = asyncpg.Record
-except ImportError:
-    pass
-try:
-    import sqlite3
-
-    UniqueError = sqlite3.IntegrityError
-    Record = sqlite3.Row
-except ImportError:
-    pass
-
-if UniqueError is None:
-    raise ImportError("Must require either asyncpg or aiosqlite!")
+from .shim import UniqueError
 
 
 def init(db: Database) -> None:

--- a/mautrix_instagram/db/portal.py
+++ b/mautrix_instagram/db/portal.py
@@ -22,7 +22,7 @@ from attr import dataclass
 from mautrix.types import ContentURI, RoomID, UserID
 from mautrix.util.async_db import Database
 
-from . import Record
+from .shim import Record
 
 fake_db = Database.create("") if TYPE_CHECKING else None
 

--- a/mautrix_instagram/db/portal.py
+++ b/mautrix_instagram/db/portal.py
@@ -18,10 +18,9 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, ClassVar
 
 from attr import dataclass
-import asyncpg
 
 from mautrix.types import ContentURI, RoomID, UserID
-from mautrix.util.async_db import Database
+from mautrix.util.async_db import Database, Row, Record
 
 fake_db = Database.create("") if TYPE_CHECKING else None
 
@@ -73,7 +72,7 @@ class Portal:
         await self.db.execute(q, *self._values)
 
     @classmethod
-    def _from_row(cls, row: asyncpg.Record) -> Portal:
+    def _from_row(cls, row: Row | Record) -> Portal:
         return cls(**row)
 
     @classmethod

--- a/mautrix_instagram/db/portal.py
+++ b/mautrix_instagram/db/portal.py
@@ -20,7 +20,9 @@ from typing import TYPE_CHECKING, ClassVar
 from attr import dataclass
 
 from mautrix.types import ContentURI, RoomID, UserID
-from mautrix.util.async_db import Database, Row, Record
+from mautrix.util.async_db import Database
+
+from . import Record
 
 fake_db = Database.create("") if TYPE_CHECKING else None
 
@@ -72,7 +74,7 @@ class Portal:
         await self.db.execute(q, *self._values)
 
     @classmethod
-    def _from_row(cls, row: Row | Record) -> Portal:
+    def _from_row(cls, row: Record) -> Portal:
         return cls(**row)
 
     @classmethod

--- a/mautrix_instagram/db/puppet.py
+++ b/mautrix_instagram/db/puppet.py
@@ -21,7 +21,9 @@ from attr import dataclass
 from yarl import URL
 
 from mautrix.types import ContentURI, SyncToken, UserID
-from mautrix.util.async_db import Database, Row, Record
+from mautrix.util.async_db import Database
+
+from . import Record
 
 fake_db = Database.create("") if TYPE_CHECKING else None
 
@@ -80,7 +82,7 @@ class Puppet:
         await self.db.execute(q, *self._values)
 
     @classmethod
-    def _from_row(cls, row: Row | Record) -> Puppet:
+    def _from_row(cls, row: Record) -> Puppet:
         data = {**row}
         base_url_str = data.pop("base_url")
         base_url = URL(base_url_str) if base_url_str is not None else None

--- a/mautrix_instagram/db/puppet.py
+++ b/mautrix_instagram/db/puppet.py
@@ -19,10 +19,9 @@ from typing import TYPE_CHECKING, ClassVar
 
 from attr import dataclass
 from yarl import URL
-import asyncpg
 
 from mautrix.types import ContentURI, SyncToken, UserID
-from mautrix.util.async_db import Database
+from mautrix.util.async_db import Database, Row, Record
 
 fake_db = Database.create("") if TYPE_CHECKING else None
 
@@ -81,7 +80,7 @@ class Puppet:
         await self.db.execute(q, *self._values)
 
     @classmethod
-    def _from_row(cls, row: asyncpg.Record) -> Puppet:
+    def _from_row(cls, row: Row | Record) -> Puppet:
         data = {**row}
         base_url_str = data.pop("base_url")
         base_url = URL(base_url_str) if base_url_str is not None else None

--- a/mautrix_instagram/db/puppet.py
+++ b/mautrix_instagram/db/puppet.py
@@ -23,7 +23,7 @@ from yarl import URL
 from mautrix.types import ContentURI, SyncToken, UserID
 from mautrix.util.async_db import Database
 
-from . import Record
+from .shim import Record
 
 fake_db = Database.create("") if TYPE_CHECKING else None
 

--- a/mautrix_instagram/db/shim.py
+++ b/mautrix_instagram/db/shim.py
@@ -1,0 +1,17 @@
+try:
+    import asyncpg
+
+    UniqueError = asyncpg.UniqueViolationError
+    Record = asyncpg.Record
+except ImportError:
+    pass
+try:
+    import sqlite3
+
+    UniqueError = sqlite3.IntegrityError
+    Record = sqlite3.Row
+except ImportError:
+    pass
+
+if UniqueError is None:
+    raise ImportError("Must require either asyncpg or aiosqlite!")

--- a/mautrix_instagram/db/user.py
+++ b/mautrix_instagram/db/user.py
@@ -23,7 +23,7 @@ from mauigpapi.state import AndroidState
 from mautrix.types import RoomID, UserID
 from mautrix.util.async_db import Database
 
-from . import Record
+from .shim import Record
 
 fake_db = Database.create("") if TYPE_CHECKING else None
 

--- a/mautrix_instagram/db/user.py
+++ b/mautrix_instagram/db/user.py
@@ -18,11 +18,10 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, ClassVar
 
 from attr import dataclass
-import asyncpg
 
 from mauigpapi.state import AndroidState
 from mautrix.types import RoomID, UserID
-from mautrix.util.async_db import Database
+from mautrix.util.async_db import Database, Row, Record
 
 fake_db = Database.create("") if TYPE_CHECKING else None
 
@@ -68,7 +67,7 @@ class User:
         await self.db.execute(q, self.mxid, self.seq_id, self.snapshot_at_ms)
 
     @classmethod
-    def _from_row(cls, row: asyncpg.Record) -> User:
+    def _from_row(cls, row: Row | Record) -> User:
         data = {**row}
         state_str = data.pop("state")
         return cls(state=AndroidState.parse_json(state_str) if state_str else None, **data)

--- a/mautrix_instagram/db/user.py
+++ b/mautrix_instagram/db/user.py
@@ -21,7 +21,9 @@ from attr import dataclass
 
 from mauigpapi.state import AndroidState
 from mautrix.types import RoomID, UserID
-from mautrix.util.async_db import Database, Row, Record
+from mautrix.util.async_db import Database
+
+from . import Record
 
 fake_db = Database.create("") if TYPE_CHECKING else None
 
@@ -67,7 +69,7 @@ class User:
         await self.db.execute(q, self.mxid, self.seq_id, self.snapshot_at_ms)
 
     @classmethod
-    def _from_row(cls, row: Row | Record) -> User:
+    def _from_row(cls, row: Record) -> User:
         data = {**row}
         state_str = data.pop("state")
         return cls(state=AndroidState.parse_json(state_str) if state_str else None, **data)

--- a/mautrix_instagram/portal.py
+++ b/mautrix_instagram/portal.py
@@ -24,13 +24,6 @@ import mimetypes
 import re
 import time
 
-try:
-    import asyncpg
-    UNIQUE_ERROR = asyncpg.UniqueViolationError
-except ImportError:
-    import sqlite3
-    UNIQUE_ERROR = sqlite3.IntegrityError
-
 import magic
 
 from mauigpapi.types import (
@@ -78,7 +71,7 @@ from mautrix.util.simple_lock import SimpleLock
 
 from . import matrix as m, puppet as p, user as u
 from .config import Config
-from .db import Message as DBMessage, Portal as DBPortal, Reaction as DBReaction
+from .db import Message as DBMessage, Portal as DBPortal, Reaction as DBReaction, UniqueError
 
 if TYPE_CHECKING:
     from .__main__ import InstagramBridge
@@ -519,7 +512,7 @@ class Portal(DBPortal, BasePortal):
                     sender=sender.igpk,
                     ig_timestamp=int(resp.payload.timestamp),
                 ).insert()
-            except UNIQUE_ERROR as e:
+            except UniqueError as e:
                 self.log.warning(
                     f"Error while persisting {event_id} ({resp.payload.client_context}) "
                     f"-> {resp.payload.item_id}: {e}"

--- a/mautrix_instagram/portal.py
+++ b/mautrix_instagram/portal.py
@@ -24,7 +24,13 @@ import mimetypes
 import re
 import time
 
-import asyncpg
+try:
+    import asyncpg
+    UNIQUE_ERROR = asyncpg.UniqueViolationError
+except ImportError:
+    import sqlite3
+    UNIQUE_ERROR = sqlite3.IntegrityError
+
 import magic
 
 from mauigpapi.types import (
@@ -513,7 +519,7 @@ class Portal(DBPortal, BasePortal):
                     sender=sender.igpk,
                     ig_timestamp=int(resp.payload.timestamp),
                 ).insert()
-            except asyncpg.UniqueViolationError as e:
+            except UNIQUE_ERROR as e:
                 self.log.warning(
                     f"Error while persisting {event_id} ({resp.payload.client_context}) "
                     f"-> {resp.payload.item_id}: {e}"

--- a/optional-requirements.txt
+++ b/optional-requirements.txt
@@ -10,3 +10,6 @@ prometheus_client>=0.6,<0.15
 
 #/imageconvert
 pillow>=4,<10
+
+#/sqlite
+aiosqlite>=0.16,<0.18

--- a/optional-requirements.txt
+++ b/optional-requirements.txt
@@ -11,5 +11,8 @@ prometheus_client>=0.6,<0.15
 #/imageconvert
 pillow>=4,<10
 
+#/postgres
+asyncpg>=0.20,<0.26
+
 #/sqlite
 aiosqlite>=0.16,<0.18

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,5 @@ aiohttp>=3,<4
 yarl>=1,<2
 attrs>=20.1
 mautrix>=0.15.7,<0.17
-asyncpg>=0.20,<0.26
 pycryptodome>=3,<4
 paho-mqtt>=1.5,<2


### PR DESCRIPTION
This is mostly making the type checker happy (hopefully), but there are two main compatibility bits:
 - Handling the unique constraint exception (handled with try/except imports)
 - `ALTER COLUMN` doesn't exist in SQLite, but there is a [somewhat terrifying but officially-endorsed workaround](https://www.sqlite.org/lang_altertable.html#otheralter) that I've implemented here