### PR TITLE
backfill: actually use lock to prevent races from User.handle_message

### DIFF
--- a/mautrix_instagram/user.py
+++ b/mautrix_instagram/user.py
@@ -680,6 +680,7 @@ class User(DBUser, BaseUser):
                 return
         self.log.trace(f"Received message sync event {evt.message}")
         sender = await pu.Puppet.get_by_pk(evt.message.user_id) if evt.message.user_id else None
+        await portal.backfill_lock.wait(f"{evt.message.op} {evt.message.item_id}")
         if evt.message.op == Operation.ADD:
             if not sender:
                 # I don't think we care about adds with no sender


### PR DESCRIPTION
Signed-off-by: Sumner Evans <sumner@beeper.com>
