### PR TITLE
fix(portal): force encoding video

### DIFF
--- a/mautrix_instagram/portal.py
+++ b/mautrix_instagram/portal.py
@@ -413,13 +413,18 @@ class Portal(DBPortal, BasePortal):
         width: int | None = None,
         height: int | None = None,
     ) -> CommandResponse:
-        if mime_type != "video/mp4":
-            data = await ffmpeg.convert_bytes(
-                data,
-                output_extension=".mp4",
-                output_args=("-c:v", "libx264", "-c:a", "aac"),
-                input_mime=mime_type,
-            )
+        self.log.trace(f"Encoding video from {event_id}")
+        data = await ffmpeg.convert_bytes(
+            data,
+            output_extension=".mp4",
+            output_args=(
+                "-c:v",
+                "libx264",
+                "-c:a",
+                "aac",
+            ),
+            input_mime=mime_type,
+        )
 
         self.log.trace(f"Uploading video from {event_id}")
         _, upload_id = await sender.client.upload_mp4(


### PR DESCRIPTION
This seems to fix #47, unfortunately it is incredibly hard to test, some videos pass, others don't.
I made tests using iPhone clips (which should be `mov` format with `video/quicktime` MIME) but Synapse or the Matrix client (Element) seems to convert the video to mp4 upfront but, it doesn't use the same encoding parameters as this library does.

It could be nice if someone can do some other tests on multiple devices (iPhone, Android, etc.), but in any case, this commit is not breaking.