### PR TITLE
backfill: if the reaction has no timestamp, use the message timestamp

### DIFF
--- a/mautrix_instagram/portal.py
+++ b/mautrix_instagram/portal.py
@@ -2163,7 +2163,7 @@ class Portal(DBPortal, BasePortal):
                             content=reaction_event,
                             type=EventType.REACTION,
                             sender=intent.mxid,
-                            timestamp=reaction.timestamp_ms,
+                            timestamp=reaction.timestamp_ms or message.timestamp_ms,
                         )
                     )
 


### PR DESCRIPTION
Signed-off-by: Sumner Evans <sumner@beeper.com>
