### PR TITLE
Add 5s wait for connected on handling sends

### DIFF
--- a/mautrix_instagram/portal.py
+++ b/mautrix_instagram/portal.py
@@ -535,7 +535,7 @@ class Portal(DBPortal, BasePortal):
     ) -> None:
         sender, is_relay = await self.get_relay_sender(orig_sender, f"message {event_id}")
         assert sender, "user is not logged in"
-        assert sender.is_connected, "You're not connected to Instagram"
+        await sender.ensure_connected()
 
         if is_relay:
             await self.apply_relay_message_format(orig_sender, message)
@@ -727,8 +727,7 @@ class Portal(DBPortal, BasePortal):
             await self._send_bridge_success(sender, redaction_event_id, EventType.ROOM_REDACTION)
 
     async def _handle_matrix_redaction(self, sender: u.User, event_id: EventID) -> None:
-        if not sender.is_connected:
-            raise Exception("You're not connected to Instagram")
+        await sender.ensure_connected()
 
         reaction = await DBReaction.get_by_mxid(event_id, self.mxid)
         if reaction:

--- a/mautrix_instagram/user.py
+++ b/mautrix_instagram/user.py
@@ -100,7 +100,6 @@ BridgeState.human_readable_errors.update(
         "ig-checkpoint-locked": "Instagram checkpoint error. Please check the Instagram website.",
         "ig-rate-limit": "Got Instagram ratelimit error, waiting a few minutes before retrying...",
         "ig-disconnected": None,
-        "ig-no-mqtt": "You're not connected to Instagram",
         "logged-out": "You've been logged out of instagram, please login again to continue",
     }
 )
@@ -229,6 +228,18 @@ class User(DBUser, BaseUser):
     @property
     def is_connected(self) -> bool:
         return bool(self.client) and bool(self.mqtt) and self._is_connected
+
+    async def ensure_connected(self, max_wait_seconds: int = 5) -> None:
+        sleep_interval = 0.1
+        max_attempts = max_wait_seconds / sleep_interval
+        attempts = 0
+        while True:
+            if self.is_connected:
+                return
+            attempts += 1
+            if attempts > max_attempts:
+                raise Exception("You're not connected to instagram")
+            await asyncio.sleep(sleep_interval)
 
     async def connect(self, user: CurrentUser | None = None) -> None:
         if not self.state:


### PR DESCRIPTION
This means if we're in a temporary disconnect state when bridging a message we won't fail immediately but wait up to 5s for connection before failing as before.