### PR TITLE
media: add basic support for direct_media_collection and media_viewer

### DIFF
--- a/mauigpapi/types/thread_item.py
+++ b/mauigpapi/types/thread_item.py
@@ -507,6 +507,13 @@ class DirectMediaShareItem(SerializableAttrs):
 
 
 @dataclass
+class PreviewURLInfo(SerializableAttrs):
+    url: str
+    width: int
+    height: int
+
+
+@dataclass
 class XMAMediaShareItem(SerializableAttrs):
     xma_layout_type: int
 
@@ -520,6 +527,7 @@ class XMAMediaShareItem(SerializableAttrs):
 
     preview_url: Optional[str] = None
     preview_url_mime_type: Optional[str] = None
+    preview_url_info: Optional[PreviewURLInfo] = None
     preview_width: Optional[int] = None
     preview_height: Optional[int] = None
 


### PR DESCRIPTION
These are the fancy new album/collection things where you can send
multiple photos in a single message in Instagram.

Signed-off-by: Sumner Evans <sumner@beeper.com>
